### PR TITLE
[BUGFIX] Fix javascript errors on firefox

### DIFF
--- a/Resources/Private/JavaScripts/Components/Translations.js
+++ b/Resources/Private/JavaScripts/Components/Translations.js
@@ -16,8 +16,13 @@ let Translations = Model({
     this.el = el;
     this.tableViews = {};
     this.form = this.el.getElementsByTagName('form')[0];
-    this.locales = JSON.parse(this.el.querySelector('[data-json="locales"]').innerText);
-    this.translations = JSON.parse(this.el.querySelector('[data-json="translations"]').innerText);
+
+    let localeNode = this.el.querySelector('[data-json="locales"]');
+    this.locales = JSON.parse(localeNode.textContent || localeNode.innerText);
+
+    let translationNode = this.el.querySelector('[data-json="translations"]');
+    this.translations = JSON.parse(translationNode.textContent || translationNode.innerText);
+
     this.defaultTarget = this.el.dataset.locale || this.locales[1];
     this.render(this.locales[0], this.defaultTarget);
   },

--- a/Resources/Private/Templates/Management/TranslationManagement/Index.html
+++ b/Resources/Private/Templates/Management/TranslationManagement/Index.html
@@ -13,8 +13,8 @@
 	</noscript>
 
 	<div class="translations" data-area="Translations" data-locale="{defaultLocale}">
-		<div style="display:none;" data-json="translations">{allTranslationsJSON}</div>
-		<div style="display:none;" data-json="locales">{availableLocalesJSON}</div>
+		<div style="display:none;" data-json="translations">{allTranslationsJSON -> f:format.raw()}</div>
+		<div style="display:none;" data-json="locales">{availableLocalesJSON -> f:format.raw()}</div>
 
 		<f:form action="save"></f:form>
 

--- a/Resources/Public/JavaScripts/Main.js
+++ b/Resources/Public/JavaScripts/Main.js
@@ -530,8 +530,13 @@ var Translations = Model({
     this.el = el;
     this.tableViews = {};
     this.form = this.el.getElementsByTagName('form')[0];
-    this.locales = JSON.parse(this.el.querySelector('[data-json="locales"]').innerText);
-    this.translations = JSON.parse(this.el.querySelector('[data-json="translations"]').innerText);
+
+    var localeNode = this.el.querySelector('[data-json="locales"]');
+    this.locales = JSON.parse(localeNode.textContent || localeNode.innerText);
+
+    var translationNode = this.el.querySelector('[data-json="translations"]');
+    this.translations = JSON.parse(translationNode.textContent || translationNode.innerText);
+
     this.defaultTarget = this.el.dataset.locale || this.locales[1];
     this.render(this.locales[0], this.defaultTarget);
   },


### PR DESCRIPTION
The injected JSON configuration is now unescaped. It is
also read from the more standards compliant textContent
DOM attribute instead of innterText.

It still falls back to innerText wherever textContent is
unavailable.

Releases: masters
